### PR TITLE
Rsyslog disable logic

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 
 # Env
-default[:miner][:packages] = ['libcurl3','screen','lm-sensors']
+default[:miner][:packages] = ['curl','libcurl3','screen','lm-sensors']
 
 # Sources
 default[:miner][:gpu_driver_source] = 'https://www2.ati.com/drivers/linux/ubuntu/amdgpu-pro-17.10-414273.tar.xz'
@@ -29,3 +29,4 @@ default[:miner][:address] = 'overrideme'
 
 # Syslog
 default[:miner][:syslogsocket] = 'myhost:port'
+default[:miner][:enablesyslog] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,4 +5,4 @@ license          'GPL'
 depends          'team-base'
 description      'Installs/Configures a team miner'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.7'
+version          '0.1.8'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,4 +5,4 @@ license          'GPL'
 depends          'team-base'
 description      'Installs/Configures a team miner'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.8'
+version          '0.1.9'

--- a/recipes/syslog.rb
+++ b/recipes/syslog.rb
@@ -1,20 +1,21 @@
-if node[:miner][:enablesyslog] != false
-      # Place syslog conf
-      template "/etc/rsyslog.d/60-syslog.conf" do
-        user     'root'
-        group    'root'
-        source   '60-syslog.conf.erb'
-        mode     '0644'
-        notifies :restart, 'service[rsyslog]'
-        action   :create
-      end
+# Place syslog conf and start or stop the service
+template "/etc/rsyslog.d/60-syslog.conf" do
+      user     'root'
+      group    'root'
+      source   '60-syslog.conf.erb'
+      mode     '0644'
+      action   :create
 
-      # Restart rsyslog if template updated
-      service 'rsyslog' do
-            action :nothing
+      if node[:miner][:enablesyslog] != false
+            notifies :restart, 'service[rsyslog]'
       end
-else
-      service 'rsyslog' do
-            action :stop
+end
+
+# Manage the syslog service
+service 'rsyslog' do
+      if node[:miner][:enablesyslog] != false
+            action [:enable, :start]
+      else
+            action [:disable, :stop]
       end
 end

--- a/recipes/syslog.rb
+++ b/recipes/syslog.rb
@@ -1,14 +1,20 @@
-# Place syslog conf
-template "/etc/rsyslog.d/60-syslog.conf" do
-  user     'root'
-  group    'root'
-  source   '60-syslog.conf.erb'
-  mode     '0644'
-  notifies :restart, 'service[rsyslog]'
-  action   :create
-end
+if node[:miner][:enablesyslog] != false
+      # Place syslog conf
+      template "/etc/rsyslog.d/60-syslog.conf" do
+        user     'root'
+        group    'root'
+        source   '60-syslog.conf.erb'
+        mode     '0644'
+        notifies :restart, 'service[rsyslog]'
+        action   :create
+      end
 
-# Restart rsyslog if template updated
-service 'rsyslog' do
-      action :nothing
+      # Restart rsyslog if template updated
+      service 'rsyslog' do
+            action :nothing
+      end
+else
+      service 'rsyslog' do
+            action :stop
+      end
 end


### PR DESCRIPTION
Rsyslog is now disabled by default, but can be enabled if the attribute `node[:team][:enablesyslog]` is set to anything other than `false`. 